### PR TITLE
Update doc README.md URLs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -6,10 +6,6 @@ README.md  This file
 [fingerprints.txt](fingerprints.txt)
         PGP fingerprints of authorised release signers
 
-standards.txt
-standards.txt
-        Moved to the web, <https://www.openssl.org/docs/standards.html>
-
 [HOWTO/](HOWTO/)
         A few how-to documents; not necessarily up-to-date
 
@@ -27,4 +23,4 @@ standards.txt
         Algorithm specific EVP_PKEY documentation.
 
 Formatted versions of the manpages (apps,ssl,crypto) can be found at
-        <https://www.openssl.org/docs/manpages.html>
+        <https://docs.openssl.org/master/>


### PR DESCRIPTION
Updates the online formatted documentation link to the current URL in use, and removes standards.txt section as that doesn't exist on the website and is not in the repo and hasn't been for years from what I can find.

CLA: trivial

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
